### PR TITLE
feat: Support rendering GitBook style hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,11 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "mdbook",
+ "once_cell",
+ "regex",
+ "rust-embed",
  "semver",
+ "serde",
  "serde_json",
 ]
 
@@ -1298,6 +1302,40 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rust-embed"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.48",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,9 @@ keywords = [ "mdbook", "preprocessor", "markdown", "gitbook" ]
 [dependencies]
 clap = { version = "4.4.18", features = ["derive"] }
 mdbook = "0.4.36"
+once_cell = "1.19.0"
+regex = "1.10.2"
+rust-embed = "8.2.0"
 semver = "1.0.21"
+serde = { version = "1.0.195", features = ["serde_derive"] }
 serde_json = "1.0.111"

--- a/assets/hints-template.html
+++ b/assets/hints-template.html
@@ -1,0 +1,9 @@
+<div class="mdbook-gitbook-hints mdbook-gitbook-hints-{kind}">
+  <p class="mdbook-gitbook-hints-title">
+    <span class="mdbook-gitbook-hints-icon"></span>
+    {kind}
+  </p>
+
+  {body}
+
+</div>

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,55 @@
+.mdbook-gitbook-hints {
+  padding: 8px 16px;
+  margin-bottom: 16px;
+  border-left: 0.25em solid var(--mdbook-gitbook-hints-color);
+}
+
+.mdbook-gitbook-hints>*:first-child {
+  margin-top: 0;
+}
+
+.mdbook-gitbook-hints>*:last-child {
+  margin-bottom: 0;
+}
+
+.mdbook-gitbook-hints-title {
+  display: flex;
+  font-weight: 600;
+  align-items: center;
+  line-height: 1;
+  color: var(--mdbook-gitbook-hints-color);
+  text-transform: capitalize;
+}
+
+.mdbook-gitbook-hints-icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin-right: 0.2em;
+  background-color: currentColor;
+  -webkit-mask: no-repeat center / 100%;
+  mask: no-repeat center / 100%;
+  -webkit-mask-image: var(--mdbook-gitbook-hints-icon);
+  mask-image: var(--mdbook-gitbook-hints-icon);
+}
+
+/* Icons from https://icon-sets.iconify.design/material-symbols */
+.mdbook-gitbook-hints-info {
+  --mdbook-gitbook-hints-color: rgb(9, 105, 218);
+  --mdbook-gitbook-hints-icon: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="currentColor" d="M12 17q.425 0 .713-.288T13 16v-4q0-.425-.288-.712T12 11q-.425 0-.712.288T11 12v4q0 .425.288.713T12 17m0-8q.425 0 .713-.288T13 8q0-.425-.288-.712T12 7q-.425 0-.712.288T11 8q0 .425.288.713T12 9m0 13q-2.075 0-3.9-.788t-3.175-2.137q-1.35-1.35-2.137-3.175T2 12q0-2.075.788-3.9t2.137-3.175q1.35-1.35 3.175-2.137T12 2q2.075 0 3.9.788t3.175 2.137q1.35 1.35 2.138 3.175T22 12q0 2.075-.788 3.9t-2.137 3.175q-1.35 1.35-3.175 2.138T12 22m0-2q3.35 0 5.675-2.325T20 12q0-3.35-2.325-5.675T12 4Q8.65 4 6.325 6.325T4 12q0 3.35 2.325 5.675T12 20m0-8"%2F%3E%3C%2Fsvg%3E');
+}
+
+.mdbook-gitbook-hints-warning {
+  --mdbook-gitbook-hints-color: rgb(154, 103, 0);
+  --mdbook-gitbook-hints-icon: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="currentColor" d="M2.725 21q-.275 0-.5-.137t-.35-.363q-.125-.225-.137-.488t.137-.512l9.25-16q.15-.25.388-.375T12 3q.25 0 .488.125t.387.375l9.25 16q.15.25.138.513t-.138.487q-.125.225-.35.363t-.5.137zm1.725-2h15.1L12 6zM12 18q.425 0 .713-.288T13 17q0-.425-.288-.712T12 16q-.425 0-.712.288T11 17q0 .425.288.713T12 18m0-3q.425 0 .713-.288T13 14v-3q0-.425-.288-.712T12 10q-.425 0-.712.288T11 11v3q0 .425.288.713T12 15m0-2.5"%2F%3E%3C%2Fsvg%3E');
+}
+
+.mdbook-gitbook-hints-danger {
+  --mdbook-gitbook-hints-color: rgb(207, 34, 46);
+  --mdbook-gitbook-hints-icon: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="currentColor" d="M12 17q.425 0 .713-.288T13 16q0-.425-.288-.712T12 15q-.425 0-.712.288T11 16q0 .425.288.713T12 17m0-4q.425 0 .713-.288T13 12V8q0-.425-.288-.712T12 7q-.425 0-.712.288T11 8v4q0 .425.288.713T12 13m-3.35 7H6q-.825 0-1.412-.587T4 18v-2.65L2.075 13.4q-.275-.3-.425-.662T1.5 12q0-.375.15-.737t.425-.663L4 8.65V6q0-.825.588-1.412T6 4h2.65l1.95-1.925q.3-.275.663-.425T12 1.5q.375 0 .738.15t.662.425L15.35 4H18q.825 0 1.413.588T20 6v2.65l1.925 1.95q.275.3.425.663t.15.737q0 .375-.15.738t-.425.662L20 15.35V18q0 .825-.587 1.413T18 20h-2.65l-1.95 1.925q-.3.275-.662.425T12 22.5q-.375 0-.737-.15t-.663-.425zm.85-2l2.5 2.5l2.5-2.5H18v-3.5l2.5-2.5L18 9.5V6h-3.5L12 3.5L9.5 6H6v3.5L3.5 12L6 14.5V18zm2.5-6"%2F%3E%3C%2Fsvg%3E');
+}
+
+.mdbook-gitbook-hints-success {
+  --mdbook-gitbook-hints-color: rgb(26, 127, 55);
+  --mdbook-gitbook-hints-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36'%3E%3Cpath fill='%23000' d='M18 2a16 16 0 1 0 16 16A16 16 0 0 0 18 2m0 30a14 14 0 1 1 14-14a14 14 0 0 1-14 14' class='clr-i-outline clr-i-outline-path-1'/%3E%3Cpath fill='%23000' d='M28 12.1a1 1 0 0 0-1.41 0l-11.1 11.05l-6-6A1 1 0 0 0 8 18.53L15.49 26L28 13.52a1 1 0 0 0 0-1.42' class='clr-i-outline clr-i-outline-path-2'/%3E%3Cpath fill='none' d='M0 0h36v36H0z'/%3E%3C/svg%3E");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,88 @@
 use mdbook::book::Book;
+use mdbook::book::{BookItem, Chapter};
 use mdbook::errors::Error;
 use mdbook::preprocess::{Preprocessor, PreprocessorContext};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use rust_embed::RustEmbed;
 
-/// A no-op preprocessor.
-pub struct Nop;
+#[derive(RustEmbed)]
+#[folder = "assets/"]
+struct Asset;
 
-impl Nop {
-    pub fn new() -> Nop {
-        Nop
+/// The GitBook preprocessor.
+pub struct GitBook;
+
+impl GitBook {
+    pub fn new() -> GitBook {
+        GitBook
     }
 }
 
-impl Preprocessor for Nop {
+impl Preprocessor for GitBook {
     fn name(&self) -> &str {
-        "nop-preprocessor"
+        "gitbook"
     }
 
-    fn run(&self, _ctx: &PreprocessorContext, book: Book) -> Result<Book, Error> {
-        // we *are* a no-op preprocessor after all
-        Ok(book)
+    fn run(&self, _ctx: &PreprocessorContext, mut book: Book) -> Result<Book, Error> {
+        let mut error: Option<Error> = None;
+        book.for_each_mut(|item: &mut BookItem| {
+            if error.is_some() {
+                return;
+            }
+            if let BookItem::Chapter(ref mut chapter) = *item {
+                if let Err(err) = handle_chapter(chapter) {
+                    error = Some(err)
+                }
+            }
+        });
+        error.map_or(Ok(book), Err)
     }
 
+    /// Check whether we support the specified renderer
     fn supports_renderer(&self, renderer: &str) -> bool {
-        renderer != "not-supported"
+        renderer == "html"
     }
+}
+
+/// Apply to all chapters
+fn handle_chapter(chapter: &mut Chapter) -> Result<(), Error> {
+    chapter.content = inject_stylesheet(&chapter.content)?;
+    chapter.content = render_hints(&chapter.content)?;
+    Ok(())
+}
+
+/// Adds our stylesheet to the chapter
+fn inject_stylesheet(content: &str) -> Result<String, Error> {
+    let style = Asset::get("style.css").expect("style.css not found in assets");
+    let style = std::str::from_utf8(style.data.as_ref())?;
+    Ok(format!("<style>\n{style}\n</style>\n{content}"))
+}
+
+/// Uses regex to find [GitBook hints](https://docs.gitbook.com/content-editor/blocks/hint)
+/// and replaces them with appropriate HTML rendering
+fn render_hints(content: &str) -> Result<String, Error> {
+    static RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r#"\{% hint style="(?P<kind>[^"]+)" %\}\s*\n(?P<body>(?:.*\n)*?)\s*\{% endhint %\}"#,
+        )
+        .expect("failed to parse regex")
+    });
+    let hints = Asset::get("hints-template.html").expect("hints-template.html not found in assets");
+    let hints = std::str::from_utf8(hints.data.as_ref())?;
+    let content = RE.replace_all(content, |caps: &regex::Captures| {
+        let kind = caps
+            .name("kind")
+            .expect("kind not found in regex")
+            .as_str()
+            .to_lowercase();
+        let body = caps
+            .name("body")
+            .expect("body not found in regex")
+            .as_str()
+            .replace("\n>\n", "\n\n")
+            .replace("\n> ", "\n");
+        hints.replace("{kind}", &kind).replace("{body}", &body)
+    });
+    Ok(content.into())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Arg, ArgMatches, Command};
 use mdbook::errors::Error;
 use mdbook::preprocess::{CmdPreprocessor, Preprocessor};
-use mdbook_gitbook::Nop;
+use mdbook_gitbook::GitBook;
 use semver::{Version, VersionReq};
 use std::io;
 use std::process;
@@ -20,7 +20,7 @@ fn main() {
     let matches = make_app().get_matches();
 
     // Users will want to construct their own preprocessor here
-    let preprocessor = Nop::new();
+    let preprocessor = GitBook::new();
 
     if let Some(sub_args) = matches.subcommand_matches("supports") {
         handle_supports(&preprocessor, sub_args);


### PR DESCRIPTION
Renders `{% hint style="*****" %}` style hints similar to how GitBook does it

Turns
```markdown
# Hints

{% hint style="info" %}
The default hint. A simple info box.
{% endhint %}

{% hint style="warning" %}
A warning.
{% endhint %}

{% hint style="danger" %}
Danger!
{% endhint %}

{% hint style="success" %}
Success :D
{% endhint %}
```
into

![image](https://github.com/GeckoEidechse/mdbook-gitbook/assets/40122905/4f6e8a70-4329-403f-80ec-e69a490937f6)




Logic inspired by https://github.com/lambdalisue/rs-mdbook-alerts
