### PR TITLE
feat: Add ability to render GitBook syntax YouTube embeds

### DIFF
--- a/assets/youtube-embed-template.html
+++ b/assets/youtube-embed-template.html
@@ -1,0 +1,5 @@
+<iframe width="560" height="315" src="https://www.youtube.com/embed/{ytid}"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+</iframe>


### PR DESCRIPTION
Turns something like
```markdown
# Embeds

## Generic

{% embed url="http://example.com/" %}

## Special cases

The following embeds are rendered in a special way, e.g. as an iframe

### YouTube

YouTube embeds are rendered as an iframe on GitBook, allowing to playback the video directly.

{% embed url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" %}
```
into

![image](https://github.com/GeckoEidechse/mdbook-gitbook/assets/40122905/bb4c64a5-ed35-4c96-a991-1b842df38590)
